### PR TITLE
Allow dt_admin to edit_others_posts so they can edit any webform

### DIFF
--- a/includes/post-type-active-forms.php
+++ b/includes/post-type-active-forms.php
@@ -131,6 +131,7 @@ class DT_Webform_Active_Form_Post_Type
         'publicly_queryable'    => false,
         'capabilities' => [
             'edit_post' => 'manage_dt',
+            'edit_others_posts' => 'manage_dt',
             'delete_post' => 'manage_dt'
         ],
         'capability_type'       => 'post',


### PR DESCRIPTION
A DT Admin user was previously not able to edit a webform that was created by another user. This allows them to do so.